### PR TITLE
Disable MacOS quarantine for unsigned application

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,11 @@ to use **Bed Leveler 5000**.
    ```
    chmod +x BedLeveler5000 PrinterInfoWizard InspectorG-code PrinterTester
    ```
-8) Run desired application
+8) Disable quarantine as the applications are unsigned
+   ```
+   xattr -d com.apple.quarantine -r .
+   ```
+9) Run desired application
     - Bed Leveler 5000
       ```
       ./BedLeveler5000


### PR DESCRIPTION
For most MacOS Setups, BedLevel5000 also won't run as it is an Unsigned app. I've added the instructions to disable quarantine on the BedLevel5000 programs so that it will start.